### PR TITLE
Fix GM summary handling on load

### DIFF
--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -68,4 +68,10 @@ class BaseAgent:
     def load_memory(self, filepath: Path) -> None:
         """Load the conversation history from a file."""
         if filepath.exists():
-            self.messages = eval(filepath.read_text()) 
+            self.messages = eval(filepath.read_text())
+
+    def remove_last_messages(self, count: int) -> None:
+        """Remove the last `count` messages from the history."""
+        if count <= 0:
+            return
+        self.messages = self.messages[:-count]

--- a/app/core/turn_engine.py
+++ b/app/core/turn_engine.py
@@ -93,18 +93,21 @@ class TurnEngine:
 
     def generate_summary(self) -> str:
         """Generate a summary of the story so far using the GM's context."""
-        # Get all messages from GM's context
         messages = self.gm.get_messages()
         if not messages:
             return "No story progress yet."
-        
-        # Create a prompt for summary generation
-        summary_prompt = "Based on the following conversation history, provide a brief summary of what has happened in the story so far:\n\n"
-        for msg in messages:
-            summary_prompt += f"{msg['role']}: {msg['content']}\n"
-        
-        # Get summary from GM
+
+        # Ask the GM for a summary based on its existing context
+        summary_prompt = (
+            "Please provide a brief summary of what has happened in the story so far."
+        )
         summary = self.gm.process_turn(summary_prompt)
+
+        # Remove the summary prompt and response from the GM's context
+        self.gm.remove_last_messages(2)
+        if self.story_dir:
+            self.gm.save_memory(self.story_dir / "gm_memory.json")
+
         return summary
 
     def process_turn(self, player_input: Optional[str] = None) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- remove the entire conversation dump when requesting a summary
- strip the summary prompt and response from GM memory after generating summary
- add helper to BaseAgent for removing messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684023ac851883249f082059b500ad88