### PR TITLE
Fix GM context not restored on reload

### DIFF
--- a/app/agents/game_master.py
+++ b/app/agents/game_master.py
@@ -24,6 +24,7 @@ You should:
 - Let the player character and partner maintain their agency
 - Focus on describing the world and NPCs' reactions
 - Do not use fourth wall breaking terms like "NPCs" or "player character"
+- Keep your responses to 1 paragraph if possible
 - Do not ask the player to make decisions, just narrate the world and respond to the player character's actions through NPCs and the world
 
 Remember: The player character and their partner are the protagonists. Your job is to create an engaging world for them to explore, not to control their actions."""

--- a/app/agents/partner.py
+++ b/app/agents/partner.py
@@ -22,6 +22,7 @@ For narration and actions:
 - Use your character's name when appropriate
 - Describe your actions in third person
 - Do not use fourth wall breaking terms like "NPCs" or "player character"
+- Keep your responses to 1 paragraph if possible
 
 For dialogue:
 - Use first person ("I", "me", "my") when speaking

--- a/app/core/turn_engine.py
+++ b/app/core/turn_engine.py
@@ -97,6 +97,16 @@ class TurnEngine:
         if not messages:
             return "No story progress yet."
 
+        # Before we ask the GM for a summary, put anything in the this.since_gm_last_turn into the GM's context
+        if self.since_gm_last_turn:
+            # Build a comprehensive message of what happened since GM's last turn
+            message = "Here's what happened since your last turn:\n"
+            for event in self.since_gm_last_turn:
+                message += f"- {event}\n"
+            message += "What happens next?"
+            self.gm.add_message("user", message)
+            self.since_gm_last_turn = []
+
         # Ask the GM for a summary based on its existing context
         summary_prompt = (
             "Please provide a brief summary of what has happened in the story so far."

--- a/app/core/turn_engine.py
+++ b/app/core/turn_engine.py
@@ -278,3 +278,19 @@ class TurnEngine:
                 "partner": "Partner",
             }.get(msg["role"], msg["role"].capitalize())
             self.since_partner_last_turn.append(f"{prefix}: {msg['content']}")
+
+        # Rebuild the "since_gm_last_turn" context
+        self.since_gm_last_turn = []
+        last_gm_idx = -1
+        for i in range(len(self.message_history) - 1, -1, -1):
+            if self.message_history[i]["role"] == "gm":
+                last_gm_idx = i
+                break
+
+        for msg in self.message_history[last_gm_idx + 1 :]:
+            prefix = {
+                "gm": "GM",
+                "player": "Player",
+                "partner": "Partner",
+            }.get(msg["role"], msg["role"].capitalize())
+            self.since_gm_last_turn.append(f"{prefix}: {msg['content']}")


### PR DESCRIPTION
## Summary
- rebuild GM turn history when loading saved game state

## Testing
- `python -m py_compile app/core/turn_engine.py`
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_6840c5e65d4c8324b7fbc3187ff209d4